### PR TITLE
Remove implicit dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,13 +10,15 @@ jobs:
     strategy:
       matrix:
         node-version:
+          - 10.x # deprecated
           - 11.x # deprecated
-          - 12.x # maintainence ends 2022-04-30
+          - 12.x # deprecated
           - 13.x # deprecated
-          - 14.x # maintainence ends 2023-04-30
+          - 14.x # maintenance ends 2023-04-30
           - 15.x # deprecated
-          - 16.x # maintainence ends 2024-04-30
-          - 17.x # maintainence ends 2022-06-01
+          - 16.x # maintenance ends 2024-04-30
+          - 17.x # deprecated
+          - 18.x # maintenance ends 2025-04-30
     steps:
       - uses: actions/setup-node@v3
       - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "jest": "28.1.3",
     "husky": "8.0.1",
-    "jest": "^28.1.3",
+    "jest": "28.1.3",
     "lint-staged": "13.0.3",
     "prettier": "2.7.1"
   },

--- a/package.json
+++ b/package.json
@@ -24,10 +24,9 @@
     "url": "https://github.com/philihp/eslint-config/issues"
   },
   "homepage": "https://github.com/philihp/eslint-config#readme",
-  "dependencies": {
-    "@babel/eslint-parser": "7.18.9",
-    "babel-jest": "28.1.3",
-    "eslint": "8.20.0",
+  "dependencies": {},
+  "devDependencies": {
+    "eslint": "8.19.0",
     "eslint-config-airbnb": "19.0.4",
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-import": "2.26.0",
@@ -38,12 +37,9 @@
     "eslint-plugin-react": "7.30.1",
     "eslint-plugin-react-hooks": "4.6.0",
     "jest": "28.1.3",
-    "prettier": "2.7.1",
-    "react": "18.2.0"
-  },
-  "devDependencies": {
     "husky": "8.0.1",
-    "lint-staged": "13.0.3"
+    "lint-staged": "13.0.3",
+    "prettier": "2.7.1"
   },
   "prettier": {
     "singleQuote": true,

--- a/package.json
+++ b/package.json
@@ -24,10 +24,9 @@
     "url": "https://github.com/philihp/eslint-config/issues"
   },
   "homepage": "https://github.com/philihp/eslint-config#readme",
-  "dependencies": {},
   "devDependencies": {
-    "@babel/eslint-parser": "7.18.2",
-    "eslint": "8.19.0",
+    "@babel/eslint-parser": "7.18.9",
+    "eslint": "8.21.0",
     "eslint-config-airbnb": "19.0.4",
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-import": "2.26.0",
@@ -39,6 +38,7 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "jest": "28.1.3",
     "husky": "8.0.1",
+    "jest": "^28.1.3",
     "lint-staged": "13.0.3",
     "prettier": "2.7.1"
   },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/philihp/eslint-config#readme",
   "dependencies": {},
   "devDependencies": {
+    "@babel/eslint-parser": "7.18.2",
     "eslint": "8.19.0",
     "eslint-config-airbnb": "19.0.4",
     "eslint-config-prettier": "8.5.0",


### PR DESCRIPTION
I'm removing implicit dependencies because I think as I do more varied types of libraries, it's not fair to (for example) assume I'm doing react, or testing with jest.